### PR TITLE
feat: add tailwind and refresh home UI

### DIFF
--- a/email-builder/index.html
+++ b/email-builder/index.html
@@ -4,6 +4,24 @@
   <meta charset="UTF-8" />
   <title>Email Builder — Projects & Modules</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT: '#605bff', 600: '#4f46e5', 700: '#4338ca' },
+            ink: '#0f172a',
+            muted: '#64748b'
+          },
+          boxShadow: {
+            soft: '0 8px 24px rgba(15,23,42,.06)'
+          },
+          borderRadius: { 'xl': '0.875rem' }
+        }
+      }
+    }
+  </script>
   <style>
     :root{
       /* Color palette */
@@ -36,14 +54,6 @@
     h4{font-size:var(--fs-h4)}
     small{font-size:var(--fs-small)}
     a{color:inherit;text-decoration:none}
-    /* Header */
-    header{
-      position:sticky;top:0;z-index:10;display:flex;align-items:center;justify-content:space-between;
-      padding:var(--space-3) var(--space-4);background:linear-gradient(90deg,var(--brand),var(--brand-600));
-      color:#fff;box-shadow:var(--shadow-md)
-    }
-    header h1{font-size:var(--fs-h3);letter-spacing:.3px;font-weight:700}
-    .nav{display:flex;gap:var(--space-2);align-items:center}
     .btn{
       appearance:none;border:0;cursor:pointer;padding:var(--space-2) var(--space-3);border-radius:999px;background:var(--surface);
       color:var(--brand);font-weight:700;font-size:var(--fs-small);box-shadow:var(--shadow-sm);transition:transform .06s ease;
@@ -54,6 +64,8 @@
     .btn.danger{background:var(--danger);color:#fff}
     .btn:active{transform:translateY(1px)}
     .btn:focus-visible{outline-color:var(--brand-600)}
+    .nav{display:flex;gap:var(--space-2);align-items:center}
+    /* Header */
     main{padding:var(--space-4)}
     .hidden{display:none!important}
     .card{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);box-shadow:var(--shadow-md);overflow:hidden}
@@ -66,12 +78,6 @@
     select:focus-visible,input[type="text"]:focus-visible,textarea:focus-visible{outline-color:var(--brand-600)}
     textarea{border-radius:var(--r-md)}
     /* Home */
-    .home-wrap{display:grid;place-items:center;height:calc(100vh - 100px)}
-    .home-grid{display:grid;grid-template-columns:repeat(2, minmax(220px, 300px));gap:20px}
-    .home-tile{
-      display:flex;align-items:center;justify-content:center;gap:10px;height:140px;background:#fff;border:1px solid var(--border);
-      border-radius:20px;box-shadow:var(--shadow-md);font-weight:800;font-size:20px;cursor:pointer
-    }
     /* Projects list */
     .list{padding:12px}
     .proj-row{
@@ -111,22 +117,36 @@
   </style>
 </head>
 <body>
-  <header>
-    <h1>Email Builder</h1>
-    <div class="nav">
-      <button class="btn secondary" onclick="go('#/')">Home</button>
-      <button class="btn secondary" onclick="go('#/projects')">Projects</button>
-      <button class="btn secondary" onclick="go('#/modules')">Modules</button>
-      <button id="btnCopy" class="btn hidden" title="Copy Final HTML from Composer">Copy HTML</button>
+  <header class="sticky top-0 z-10 w-full bg-gradient-to-r from-brand to-violet-600 text-white shadow">
+    <div class="mx-auto max-w-6xl flex items-center justify-between px-4 py-3">
+      <h1 class="text-base font-bold tracking-tight">Email Builder</h1>
+      <nav class="flex items-center gap-2">
+        <a href="#/" class="inline-flex items-center rounded-full bg-white/10 px-3 py-1.5 text-sm font-semibold hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Home</a>
+        <a href="#/projects" class="inline-flex items-center rounded-full bg-white/10 px-3 py-1.5 text-sm font-semibold hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Projects</a>
+        <a href="#/modules" class="inline-flex items-center rounded-full bg-white/10 px-3 py-1.5 text-sm font-semibold hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Modules</a>
+        <button id="btnCopy" class="hidden inline-flex items-center rounded-full bg-white/10 px-3 py-1.5 text-sm font-semibold hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white" title="Copy Final HTML from Composer">Copy HTML</button>
+      </nav>
     </div>
   </header>
 
   <main>
     <!-- HOME -->
-    <section id="view-home" class="home-wrap">
-      <div class="home-grid">
-        <div class="home-tile" onclick="go('#/projects')">📄 Projects</div>
-        <div class="home-tile" onclick="go('#/modules')">🧩 Modules</div>
+    <section id="view-home" class="flex flex-col items-center justify-center text-center py-20">
+      <div>
+        <h2 class="text-3xl font-bold tracking-tight text-ink">Build Emails Fast</h2>
+        <p class="mt-2 text-lg text-muted">Manage projects and modules to craft emails in seconds.</p>
+        <div class="grid gap-6 sm:grid-cols-2 mt-10">
+          <a href="#/projects" class="group rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg">
+            <span class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-brand">📄</span>
+            <h3 class="text-lg font-semibold text-slate-900">Projects</h3>
+            <p class="mt-1 text-sm text-slate-600">View and manage email builds.</p>
+          </a>
+          <a href="#/modules" class="group rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg">
+            <span class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-brand">🧩</span>
+            <h3 class="text-lg font-semibold text-slate-900">Modules</h3>
+            <p class="mt-1 text-sm text-slate-600">Create and edit reusable blocks.</p>
+          </a>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- integrate Tailwind CDN and config for custom brand palette
- modernize header navigation and copy button styling
- redesign home view with hero section and action cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a544304414833391e74c6d0385dd51