### PR TITLE
Move Projects and Modules buttons to sidebar

### DIFF
--- a/email-builder/index.html
+++ b/email-builder/index.html
@@ -131,7 +131,7 @@
   </header>
 
   <div class="flex min-h-screen">
-    <aside class="hidden md:block w-48 bg-white border-r">
+    <aside class="w-48 bg-white border-r">
       <nav class="flex flex-col p-4 space-y-2">
         <a href="#/" class="rounded px-3 py-2 hover:bg-slate-100">Home</a>
         <a href="#/projects" class="rounded px-3 py-2 hover:bg-slate-100">Projects</a>
@@ -147,18 +147,7 @@
       <div>
         <h2 class="text-3xl font-bold tracking-tight text-ink">Build Emails Fast</h2>
         <p class="mt-2 text-lg text-muted">Manage projects and modules to craft emails in seconds.</p>
-        <div class="grid gap-6 sm:grid-cols-2 mt-10">
-          <a href="#/projects" class="group rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg">
-            <span class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-brand">📄</span>
-            <h3 class="text-lg font-semibold text-slate-900">Projects</h3>
-            <p class="mt-1 text-sm text-slate-600">View and manage email builds.</p>
-          </a>
-          <a href="#/modules" class="group rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-soft transition hover:-translate-y-0.5 hover:shadow-lg">
-            <span class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-brand">🧩</span>
-            <h3 class="text-lg font-semibold text-slate-900">Modules</h3>
-            <p class="mt-1 text-sm text-slate-600">Create and edit reusable blocks.</p>
-          </a>
-        </div>
+        <p class="mt-10 text-sm text-slate-600">Use the sidebar to navigate between projects and modules.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- remove homepage cards for Projects and Modules
- show Projects and Modules links in always-visible left sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60e925ba88333bc0a7fb22699da4e