### PR TITLE
Modula UI: Tailwind CDN + redesigned Home (nav, hero, cards)

### DIFF
--- a/email-builder/index.html
+++ b/email-builder/index.html
@@ -119,35 +119,66 @@
     .muted{color:var(--muted)}
   </style>
 </head>
-<body class="font-sans">
-  <header class="sticky top-0 z-10 w-full bg-gradient-to-r from-brand to-violet-600 text-white shadow">
+<body class="font-sans bg-slate-50 text-slate-900">
+  <header class="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
     <div class="mx-auto max-w-6xl flex items-center justify-between px-4 py-3">
-      <h1 class="text-base font-bold tracking-tight">Email Builder</h1>
-      <div class="flex items-center gap-2">
+      <a href="#/" class="flex items-center gap-2 text-xl font-semibold">
+        <span class="text-brand">&lt;/&gt;</span>
+        <span>Modula</span>
+      </a>
+      <nav class="flex items-center gap-6">
+        <a href="#/projects" class="text-sm font-medium hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2">Projects</a>
+        <a href="#/modules" class="text-sm font-medium hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2">Modules</a>
+        <a href="#/composer" class="rounded-full bg-brand px-6 py-2 text-sm font-medium text-white shadow-soft hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2">Composer</a>
         <div id="userSpot"></div>
-        <button id="btnCopy" class="hidden inline-flex items-center rounded-full bg-white/10 px-3 py-1.5 text-sm font-semibold hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white" title="Copy Final HTML from Composer">Copy HTML</button>
-      </div>
+        <button id="btnCopy" class="hidden rounded-full bg-brand px-3 py-1.5 text-sm font-medium text-white shadow-soft hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2" title="Copy Final HTML from Composer">Copy HTML</button>
+      </nav>
     </div>
   </header>
 
-  <div class="flex min-h-screen">
-    <aside class="w-48 bg-white border-r">
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="#/" class="rounded px-3 py-2 hover:bg-slate-100">Home</a>
-        <a href="#/projects" class="rounded px-3 py-2 hover:bg-slate-100">Projects</a>
-        <a href="#/modules" class="rounded px-3 py-2 hover:bg-slate-100">Modules</a>
-        <a href="#/composer" class="rounded px-3 py-2 hover:bg-slate-100">Composer</a>
-      </nav>
-    </aside>
-
-    <main class="flex-1">
-      <div class="mx-auto max-w-5xl p-4">
+  <main>
+    <div class="mx-auto max-w-5xl p-4">
     <!-- HOME -->
-    <section id="view-home" class="flex flex-col items-center justify-center text-center py-20">
-      <div>
-        <h2 class="text-3xl font-bold tracking-tight text-ink">Build Emails Fast</h2>
-        <p class="mt-2 text-lg text-muted">Manage projects and modules to craft emails in seconds.</p>
-        <p class="mt-10 text-sm text-slate-600">Use the sidebar to navigate between projects and modules.</p>
+    <section id="view-home" class="py-24">
+      <div class="mx-auto max-w-5xl text-center">
+        <span class="mb-6 inline-block rounded-full border border-slate-200 bg-white px-4 py-1.5 text-sm text-muted">Email builder</span>
+        <h1 class="text-4xl font-bold tracking-tight sm:text-5xl">Build modular emails faster</h1>
+        <p class="mt-4 text-lg text-muted">Compose campaigns in minutes by assembling reusable modules.</p>
+        <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <a href="#/projects" class="rounded-full bg-brand px-6 py-3 text-base font-medium text-white shadow-soft hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2">Projects</a>
+          <a href="#/modules" class="rounded-full bg-brand px-6 py-3 text-base font-medium text-white shadow-soft hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2">Modules</a>
+        </div>
+      </div>
+
+      <div class="mx-auto mt-20 grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2">
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-soft">
+          <h3 class="mb-4 text-lg font-semibold">Recent Projects</h3>
+          <div class="space-y-2 text-sm text-muted">
+            <div class="h-3 w-3/4 rounded bg-slate-100"></div>
+            <div class="h-3 w-2/3 rounded bg-slate-100"></div>
+            <div class="h-3 w-1/2 rounded bg-slate-100"></div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-soft">
+          <h3 class="mb-4 text-lg font-semibold">Quick Actions</h3>
+          <div class="space-y-2 text-sm text-muted">
+            <div class="h-3 w-1/2 rounded bg-slate-100"></div>
+            <div class="h-3 w-2/3 rounded bg-slate-100"></div>
+            <div class="h-3 w-1/3 rounded bg-slate-100"></div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-soft">
+          <h3 class="mb-4 text-lg font-semibold">Module Library</h3>
+          <div class="space-y-2 text-sm text-muted">
+            <div class="h-3 w-2/3 rounded bg-slate-100"></div>
+            <div class="h-3 w-3/4 rounded bg-slate-100"></div>
+            <div class="h-3 w-1/2 rounded bg-slate-100"></div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-soft">
+          <h3 class="mb-4 text-lg font-semibold">Live Preview</h3>
+          <div class="h-32 rounded bg-slate-100"></div>
+        </div>
       </div>
     </section>
 
@@ -227,7 +258,6 @@
     <section id="view-auth" class="card hidden"></section>
       </div>
   </main>
-    </div>
 
     <!-- Tag dialog -->
     <div id="tagDialog" class="hidden fixed inset-0 bg-black/50 items-center justify-center">


### PR DESCRIPTION
## Summary
- Replace sidebar with sticky top navigation bar linking to Projects, Modules, and Composer
- Rebuild Home view with hero section and dashboard preview cards styled via Tailwind
- Apply Tailwind + Inter font, set base body styles

## Testing
- `python3 -m http.server 8080 &` + `curl -I http://localhost:8080/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a881ecef648333977dded38dc6088e